### PR TITLE
Establishes design system foundation: tokens, fonts, types, and dependencies

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,39 +4,57 @@
 @plugin "@tailwindcss/typography";
 
 @theme {
+  /* --- Colors --- */
   --color-primary: #80A1D4;
   --color-secondary: #355834;
   --color-tertiary: #14281D;
   --color-accent: #FFDB00;
   --color-neutral: #6E633D;
+  --color-error: #C0392B;
 
-  --font-family-serif: 'Lora', serif;
-  --font-family-sans: 'Manrope', sans-serif;
+  /* --- Type scale --- */
+  --text-display: 3.5rem;
+  --text-display--line-height: 1.1;
+  --text-h1: 2.75rem;
+  --text-h1--line-height: 1.15;
+  --text-h2: 2rem;
+  --text-h2--line-height: 1.2;
+  --text-h3: 1.5rem;
+  --text-h3--line-height: 1.3;
+  --text-h4: 1.125rem;
+  --text-h4--line-height: 1.4;
+  --text-body: 1rem;
+  --text-body--line-height: 1.6;
+  --text-small: 0.875rem;
+  --text-small--line-height: 1.5;
+  --text-label: 0.75rem;
+  --text-label--line-height: 1.4;
+
+  /* --- Border radius --- */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 16px;
+  --radius-full: 9999px;
+
+  /* --- Shadows --- */
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.12);
+  --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.18);
 }
 
-html,
-body {
-  padding: 0;
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+/* --- Motion tokens --- */
+:root {
+  --duration-fast: 150ms;
+  --duration-base: 200ms;
+  --duration-page: 300ms;
+  --ease-default: ease-in-out;
+  --ease-page: ease-out;
 }
 
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
-* {
-  box-sizing: border-box;
-}
-
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
-  body {
-    color: white;
-    background: black;
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,18 @@
 import type { Metadata } from 'next'
+import { Lora, Red_Hat_Display } from 'next/font/google'
 import './globals.css'
+
+const lora = Lora({
+  subsets: ['latin'],
+  variable: '--font-serif',
+  display: 'swap',
+})
+
+const redHatDisplay = Red_Hat_Display({
+  subsets: ['latin'],
+  variable: '--font-sans',
+  display: 'swap',
+})
 
 export const metadata: Metadata = {
   title: 'Quarterly Learnings',
@@ -12,7 +25,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
+    <html lang="en" className={`${lora.variable} ${redHatDisplay.variable}`}>
       <body>{children}</body>
     </html>
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@tailwindcss/postcss": "^4.2.2",
+        "cva": "^0.0.0",
         "gray-matter": "^4.0.3",
+        "lucide-react": "^1.7.0",
         "next": "^15.5.14",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -2260,6 +2262,12 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cva": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/cva/-/cva-0.0.0.tgz",
+      "integrity": "sha512-KPdxLxXhIzmCNtGpqdONKC1JwEx0cDH8cnYh7KYFxO7JYf4DqqtcLg6g+1QA0SlIdME18n9m337DOxIlrsSF5Q==",
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -4875,6 +4883,15 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
+      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {
@@ -8510,6 +8527,11 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true
     },
+    "cva": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/cva/-/cva-0.0.0.tgz",
+      "integrity": "sha512-KPdxLxXhIzmCNtGpqdONKC1JwEx0cDH8cnYh7KYFxO7JYf4DqqtcLg6g+1QA0SlIdME18n9m337DOxIlrsSF5Q=="
+    },
     "damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -10147,6 +10169,12 @@
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
+    },
+    "lucide-react": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
+      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "requires": {}
     },
     "magic-string": {
       "version": "0.30.21",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.2.2",
+    "cva": "^0.0.0",
     "gray-matter": "^4.0.3",
+    "lucide-react": "^1.7.0",
     "next": "^15.5.14",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/types/case-study.ts
+++ b/types/case-study.ts
@@ -1,0 +1,9 @@
+export type CaseStudy = {
+  client: string
+  industry: string
+  service: 'training' | 'ai-implementation'
+  challenge: string
+  approach: string
+  outcome: string
+  testimonial?: string
+}


### PR DESCRIPTION
- Expands globals.css @theme with the full token set: colors (+ --color-error), type scale (display → label with size and line-height), border radius, shadows, and
  motion tokens (--duration-*, --ease-*) in :root
- Loads Lora and Red Hat Display via next/font/google; each font sets its variable (--font-serif, --font-sans) directly on <html>, overriding Tailwind's defaults with
   no @theme indirection
- Removes hardcoded font stack, dark mode media query, and legacy base styles from old Pages Router setup
- Adds types/case-study.ts with the CaseStudy type per PRD schema
- Installs cva and lucide-react
- prefers-reduced-motion reset included

Spacing scale not redefined in @theme — Tailwind's default 4px base unit already matches the PRD's space-* tokens exactly.

  Closes DEV-42
