### PR TITLE
DEV-34: Composite components — Hero, PageHeader, CTABanner, TestimonialBlock

### DIFF
--- a/components/CTABanner/CTABanner.stories.tsx
+++ b/components/CTABanner/CTABanner.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { CTABanner } from './CTABanner'
+
+const meta: Meta<typeof CTABanner> = {
+  title: 'Components/CTABanner',
+  component: CTABanner,
+  parameters: { layout: 'fullscreen' },
+}
+
+export default meta
+type Story = StoryObj<typeof CTABanner>
+
+export const Default: Story = {
+  args: {
+    headline: 'Ready to work together?',
+    cta: { label: 'Get in touch', href: '/contact' },
+  },
+}
+
+export const WithSubtext: Story = {
+  args: {
+    headline: 'Ready to work together?',
+    subtext: "Whether you're looking to upskill your team or explore what AI can do for your business, we'd love to hear from you.",
+    cta: { label: 'Get in touch', href: '/contact' },
+  },
+}

--- a/components/CTABanner/CTABanner.tsx
+++ b/components/CTABanner/CTABanner.tsx
@@ -1,0 +1,34 @@
+import { Button } from '@/components/ui/Button'
+import { Heading } from '@/components/typography/Heading'
+import { Body } from '@/components/typography/Body'
+import { Container } from '@/components/layout/Container'
+import { Section } from '@/components/layout/Section'
+
+type CTABannerProps = {
+  headline: string
+  subtext?: string
+  cta: { label: string; href: string }
+  className?: string
+}
+
+export function CTABanner({ headline, subtext, cta, className }: CTABannerProps) {
+  return (
+    <Section background="var(--color-tertiary)" className={className}>
+      <Container>
+        <div className="flex flex-col items-center text-center gap-6">
+          <Heading level={2} className="text-white max-w-2xl">
+            {headline}
+          </Heading>
+          {subtext && (
+            <Body className="text-white/70 max-w-xl">
+              {subtext}
+            </Body>
+          )}
+          <Button variant="primary" size="lg" as="a" href={cta.href}>
+            {cta.label}
+          </Button>
+        </div>
+      </Container>
+    </Section>
+  )
+}

--- a/components/Hero/Hero.stories.tsx
+++ b/components/Hero/Hero.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Hero } from './Hero'
+
+const meta: Meta<typeof Hero> = {
+  title: 'Components/Hero',
+  component: Hero,
+  parameters: { layout: 'fullscreen' },
+}
+
+export default meta
+type Story = StoryObj<typeof Hero>
+
+export const Centered: Story = {
+  args: {
+    eyebrow: 'Technical Instruction & AI Implementation',
+    headline: 'Build the skills your team needs.',
+    subtext: 'Quarterly Learnings delivers expert-led technical training for teams and practical AI implementation for small businesses.',
+    primaryCta: { label: 'Get in touch', href: '/contact' },
+    secondaryCta: { label: 'See our work', href: '/work' },
+    variant: 'centered',
+  },
+}
+
+export const Split: Story = {
+  args: {
+    eyebrow: 'Technical Instruction & AI Implementation',
+    headline: 'Build the skills your team needs.',
+    subtext: 'Quarterly Learnings delivers expert-led technical training for teams and practical AI implementation for small businesses.',
+    primaryCta: { label: 'Get in touch', href: '/contact' },
+    secondaryCta: { label: 'See our work', href: '/work' },
+    variant: 'split',
+    image: {
+      src: '/placeholder-logo.svg',
+      alt: 'An instructor leading a technical workshop with students engaged in the foreground.',
+    },
+  },
+}
+
+export const NoEyebrow: Story = {
+  args: {
+    headline: 'Build the skills your team needs.',
+    subtext: 'Quarterly Learnings delivers expert-led technical training for teams and practical AI implementation for small businesses.',
+    primaryCta: { label: 'Get in touch', href: '/contact' },
+    variant: 'centered',
+  },
+}
+
+export const Mobile: Story = {
+  args: {
+    eyebrow: 'Technical Instruction & AI Implementation',
+    headline: 'Build the skills your team needs.',
+    subtext: 'Quarterly Learnings delivers expert-led technical training for teams and practical AI implementation for small businesses.',
+    primaryCta: { label: 'Get in touch', href: '/contact' },
+    secondaryCta: { label: 'See our work', href: '/work' },
+    variant: 'split',
+    image: {
+      src: '/placeholder-logo.svg',
+      alt: 'An instructor leading a technical workshop with students engaged in the foreground.',
+    },
+  },
+  parameters: {
+    viewport: { defaultViewport: 'mobile1' },
+  },
+}

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -1,0 +1,116 @@
+import Image from 'next/image'
+import { Button } from '@/components/ui/Button'
+import { Display } from '@/components/typography/Display'
+import { Body } from '@/components/typography/Body'
+import { Label } from '@/components/typography/Label'
+import { Container } from '@/components/layout/Container'
+
+type HeroProps = {
+  eyebrow?: string
+  headline: string
+  subtext?: string
+  primaryCta: { label: string; href: string }
+  secondaryCta?: { label: string; href: string }
+  variant?: 'centered' | 'split'
+  image?: { src: string; alt: string }
+  background?: string
+  className?: string
+}
+
+export function Hero({
+  eyebrow,
+  headline,
+  subtext,
+  primaryCta,
+  secondaryCta,
+  variant = 'centered',
+  image,
+  background = 'var(--color-tertiary)',
+  className,
+}: HeroProps) {
+  const isSplit = variant === 'split' && image
+
+  return (
+    <div
+      className={`py-20 lg:py-28 ${className ?? ''}`}
+      style={{ backgroundColor: background }}
+    >
+      <Container>
+        {isSplit ? (
+          /* Split layout — stacks on mobile, side-by-side on lg+ */
+          <div className="flex flex-col items-center text-center gap-10 lg:grid lg:grid-cols-12 lg:items-center lg:text-left lg:gap-12">
+            {/* Content — left 6 cols on desktop */}
+            <div className="lg:col-span-6 flex flex-col gap-6">
+              <HeroContent
+                eyebrow={eyebrow}
+                headline={headline}
+                subtext={subtext}
+                primaryCta={primaryCta}
+                secondaryCta={secondaryCta}
+              />
+            </div>
+            {/* Image — right 6 cols on desktop */}
+            <div className="lg:col-span-6 relative w-full aspect-[4/3] rounded-lg overflow-hidden">
+              <Image
+                src={image.src}
+                alt={image.alt}
+                fill
+                priority
+                className="object-cover"
+              />
+            </div>
+          </div>
+        ) : (
+          /* Centered layout */
+          <div className="flex flex-col items-center text-center gap-6 max-w-3xl mx-auto">
+            <HeroContent
+              eyebrow={eyebrow}
+              headline={headline}
+              subtext={subtext}
+              primaryCta={primaryCta}
+              secondaryCta={secondaryCta}
+            />
+          </div>
+        )}
+      </Container>
+    </div>
+  )
+}
+
+type HeroContentProps = Pick<HeroProps, 'eyebrow' | 'headline' | 'subtext' | 'primaryCta' | 'secondaryCta'>
+
+function HeroContent({ eyebrow, headline, subtext, primaryCta, secondaryCta }: HeroContentProps) {
+  return (
+    <>
+      {eyebrow && (
+        <Label className="text-primary uppercase tracking-widest">
+          {eyebrow}
+        </Label>
+      )}
+      <Display className="text-white">
+        {headline}
+      </Display>
+      {subtext && (
+        <Body className="text-white/70 text-h4 leading-relaxed">
+          {subtext}
+        </Body>
+      )}
+      <div className="flex flex-wrap items-center justify-center lg:justify-start gap-4 pt-2">
+        <Button variant="primary" size="lg" as="a" href={primaryCta.href}>
+          {primaryCta.label}
+        </Button>
+        {secondaryCta && (
+          <Button
+            variant="ghost"
+            size="lg"
+            as="a"
+            href={secondaryCta.href}
+            className="text-white/80 hover:text-white hover:bg-white/10"
+          >
+            {secondaryCta.label}
+          </Button>
+        )}
+      </div>
+    </>
+  )
+}

--- a/components/PageHeader/PageHeader.stories.tsx
+++ b/components/PageHeader/PageHeader.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { PageHeader } from './PageHeader'
+
+const meta: Meta<typeof PageHeader> = {
+  title: 'Components/PageHeader',
+  component: PageHeader,
+  parameters: { layout: 'fullscreen' },
+}
+
+export default meta
+type Story = StoryObj<typeof PageHeader>
+
+export const Default: Story = {
+  args: {
+    headline: 'Services',
+  },
+}
+
+export const WithEyebrow: Story = {
+  args: {
+    eyebrow: 'What we do',
+    headline: 'Services',
+  },
+}
+
+export const WithSubtext: Story = {
+  args: {
+    eyebrow: 'What we do',
+    headline: 'Services',
+    subtext: 'Technical training for teams and AI implementation for small businesses.',
+  },
+}
+
+export const CustomBackground: Story = {
+  args: {
+    eyebrow: 'Portfolio',
+    headline: 'Our Work',
+    subtext: 'A selection of client engagements and outcomes.',
+    background: 'var(--color-secondary)',
+  },
+}

--- a/components/PageHeader/PageHeader.tsx
+++ b/components/PageHeader/PageHeader.tsx
@@ -1,0 +1,45 @@
+import { Heading } from '@/components/typography/Heading'
+import { Body } from '@/components/typography/Body'
+import { Label } from '@/components/typography/Label'
+import { Container } from '@/components/layout/Container'
+
+type PageHeaderProps = {
+  eyebrow?: string
+  headline: string
+  subtext?: string
+  background?: string
+  className?: string
+}
+
+export function PageHeader({
+  eyebrow,
+  headline,
+  subtext,
+  background = 'var(--color-tertiary)',
+  className,
+}: PageHeaderProps) {
+  return (
+    <div
+      className={`py-16 lg:py-20 ${className ?? ''}`}
+      style={{ backgroundColor: background }}
+    >
+      <Container>
+        <div className="flex flex-col gap-4 max-w-3xl">
+          {eyebrow && (
+            <Label className="text-primary uppercase tracking-widest">
+              {eyebrow}
+            </Label>
+          )}
+          <Heading level={1} className="text-white">
+            {headline}
+          </Heading>
+          {subtext && (
+            <Body className="text-white/70 max-w-xl">
+              {subtext}
+            </Body>
+          )}
+        </div>
+      </Container>
+    </div>
+  )
+}

--- a/components/TestimonialBlock/TestimonialBlock.stories.tsx
+++ b/components/TestimonialBlock/TestimonialBlock.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { expect, within } from 'storybook/test'
+import { Testimonial, TestimonialContainer } from './TestimonialBlock'
+
+const meta: Meta<typeof Testimonial> = {
+  title: 'Components/TestimonialBlock',
+  component: Testimonial,
+  parameters: { layout: 'padded' },
+}
+
+export default meta
+type Story = StoryObj<typeof Testimonial>
+
+export const Single: Story = {
+  args: {
+    quote: "The training Quarterly Learnings delivered transformed how our team thinks about data. Clear, practical, and immediately applicable.",
+    name: 'Jamie Chen',
+    role: 'Engineering Manager',
+    company: 'Acme Corp',
+  },
+}
+
+export const ContainerWithItems: StoryObj<typeof TestimonialContainer> = {
+  render: () => (
+    <TestimonialContainer
+      items={[
+        {
+          quote: "The training Quarterly Learnings delivered transformed how our team thinks about data. Clear, practical, and immediately applicable.",
+          name: 'Jamie Chen',
+          role: 'Engineering Manager',
+          company: 'Acme Corp',
+        },
+        {
+          quote: "We had a vague idea that AI could help our operations. After working with Quarterly Learnings, we had a working prototype in three weeks.",
+          name: 'Marcus Webb',
+          role: 'Owner',
+          company: 'Webb & Associates',
+        },
+      ]}
+    />
+  ),
+}
+
+export const ContainerEmpty: StoryObj<typeof TestimonialContainer> = {
+  render: () => <TestimonialContainer items={[]} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    expect(canvas.queryByRole('figure')).toBeNull()
+  },
+}

--- a/components/TestimonialBlock/TestimonialBlock.tsx
+++ b/components/TestimonialBlock/TestimonialBlock.tsx
@@ -1,0 +1,43 @@
+import { Caption } from '@/components/typography/Caption'
+
+type TestimonialProps = {
+  quote: string
+  name: string
+  role?: string
+  company?: string
+  className?: string
+}
+
+type TestimonialContainerProps = {
+  items: TestimonialProps[]
+  className?: string
+}
+
+export function Testimonial({ quote, name, role, company, className }: TestimonialProps) {
+  const attribution = [role, company].filter(Boolean).join(', ')
+
+  return (
+    <figure className={`border-l-4 border-primary pl-6 ${className ?? ''}`}>
+      <blockquote className="font-serif text-h3 italic text-tertiary leading-relaxed">
+        &ldquo;{quote}&rdquo;
+      </blockquote>
+      <figcaption className="mt-4">
+        <Caption className="text-neutral font-medium not-italic">
+          — {name}{attribution ? `, ${attribution}` : ''}
+        </Caption>
+      </figcaption>
+    </figure>
+  )
+}
+
+export function TestimonialContainer({ items, className }: TestimonialContainerProps) {
+  if (!items.length) return null
+
+  return (
+    <div className={`flex flex-col gap-12 ${className ?? ''}`}>
+      {items.map((item, i) => (
+        <Testimonial key={i} {...item} />
+      ))}
+    </div>
+  )
+}

--- a/components/layout/Container/Container.tsx
+++ b/components/layout/Container/Container.tsx
@@ -1,0 +1,12 @@
+type ContainerProps = {
+  className?: string
+  children: React.ReactNode
+}
+
+export function Container({ className, children }: ContainerProps) {
+  return (
+    <div className={`mx-auto max-w-7xl px-6 sm:px-8 lg:px-20 ${className ?? ''}`}>
+      {children}
+    </div>
+  )
+}

--- a/components/layout/Container/index.ts
+++ b/components/layout/Container/index.ts
@@ -1,0 +1,1 @@
+export { Container } from './Container'

--- a/components/layout/Section/Section.tsx
+++ b/components/layout/Section/Section.tsx
@@ -1,0 +1,16 @@
+type SectionProps = {
+  background?: string
+  className?: string
+  children: React.ReactNode
+}
+
+export function Section({ background, className, children }: SectionProps) {
+  return (
+    <section
+      className={`py-16 lg:py-24 ${className ?? ''}`}
+      style={background ? { backgroundColor: background } : undefined}
+    >
+      {children}
+    </section>
+  )
+}

--- a/components/layout/Section/index.ts
+++ b/components/layout/Section/index.ts
@@ -1,0 +1,1 @@
+export { Section } from './Section'

--- a/components/typography/Body/Body.tsx
+++ b/components/typography/Body/Body.tsx
@@ -1,0 +1,13 @@
+type BodyProps = {
+  as?: React.ElementType
+  className?: string
+  children: React.ReactNode
+}
+
+export function Body({ as: Tag = 'p', className, children }: BodyProps) {
+  return (
+    <Tag className={`font-sans text-body text-neutral ${className ?? ''}`}>
+      {children}
+    </Tag>
+  )
+}

--- a/components/typography/Body/index.ts
+++ b/components/typography/Body/index.ts
@@ -1,0 +1,1 @@
+export { Body } from './Body'

--- a/components/typography/Caption/Caption.tsx
+++ b/components/typography/Caption/Caption.tsx
@@ -1,0 +1,13 @@
+type CaptionProps = {
+  as?: React.ElementType
+  className?: string
+  children: React.ReactNode
+}
+
+export function Caption({ as: Tag = 'span', className, children }: CaptionProps) {
+  return (
+    <Tag className={`font-sans text-small text-neutral ${className ?? ''}`}>
+      {children}
+    </Tag>
+  )
+}

--- a/components/typography/Caption/index.ts
+++ b/components/typography/Caption/index.ts
@@ -1,0 +1,1 @@
+export { Caption } from './Caption'

--- a/components/typography/Display/Display.tsx
+++ b/components/typography/Display/Display.tsx
@@ -1,0 +1,13 @@
+type DisplayProps = {
+  as?: React.ElementType
+  className?: string
+  children: React.ReactNode
+}
+
+export function Display({ as: Tag = 'h1', className, children }: DisplayProps) {
+  return (
+    <Tag className={`font-serif text-display text-tertiary ${className ?? ''}`}>
+      {children}
+    </Tag>
+  )
+}

--- a/components/typography/Display/index.ts
+++ b/components/typography/Display/index.ts
@@ -1,0 +1,1 @@
+export { Display } from './Display'

--- a/components/typography/Heading/Heading.tsx
+++ b/components/typography/Heading/Heading.tsx
@@ -1,0 +1,22 @@
+type HeadingProps = {
+  level: 1 | 2 | 3 | 4
+  as?: React.ElementType
+  className?: string
+  children: React.ReactNode
+}
+
+const tokenMap: Record<1 | 2 | 3 | 4, string> = {
+  1: 'font-serif text-h1',
+  2: 'font-serif text-h2',
+  3: 'font-sans text-h3',
+  4: 'font-sans text-h4',
+}
+
+export function Heading({ level, as, className, children }: HeadingProps) {
+  const Tag = (as ?? `h${level}`) as React.ElementType
+  return (
+    <Tag className={`${tokenMap[level]} text-tertiary ${className ?? ''}`}>
+      {children}
+    </Tag>
+  )
+}

--- a/components/typography/Heading/index.ts
+++ b/components/typography/Heading/index.ts
@@ -1,0 +1,1 @@
+export { Heading } from './Heading'

--- a/components/typography/Label/Label.tsx
+++ b/components/typography/Label/Label.tsx
@@ -1,0 +1,13 @@
+type LabelProps = {
+  as?: React.ElementType
+  className?: string
+  children: React.ReactNode
+}
+
+export function Label({ as: Tag = 'span', className, children }: LabelProps) {
+  return (
+    <Tag className={`font-sans text-label font-medium text-neutral ${className ?? ''}`}>
+      {children}
+    </Tag>
+  )
+}

--- a/components/typography/Label/index.ts
+++ b/components/typography/Label/index.ts
@@ -1,0 +1,1 @@
+export { Label } from './Label'


### PR DESCRIPTION
Builds the four composite page-section components that all pages from DEV-35 onward depend on. Also fills the gap from DEV-31 by building the missing
typography primitives (Display, Heading, Body, Label, Caption) and layout wrappers (Section, Container) that the composites require.

- Typography: Display, Heading (level 1–4, Lora for 1–2, Red Hat Display for 3–4), Body, Label, Caption — thin semantic wrappers over the existing
token system
- Layout: Container (max-width + responsive padding) and Section (vertical rhythm + optional background fill)
- CTABanner: Full-width dark CTA band with headline, optional subtext, and primary button
- PageHeader: Interior page title block — eyebrow, h1, optional subtext on dark background
- TestimonialBlock: Editorial pull-quote with Lora italic and primary-blue left border; container renders null on empty
- Hero: Centered and split variants; split uses a 12-column grid with next/image priority for LCP; always stacks to centered on mobile
- Storybook stories for all four composites; ContainerEmpty interaction test verifies null render