### PR TITLE
Scaffolds services and about pages

### DIFF
--- a/app/(site)/about/page.tsx
+++ b/app/(site)/about/page.tsx
@@ -1,3 +1,68 @@
+import { PageHeader } from '@/components/PageHeader/PageHeader'
+import { CTABanner } from '@/components/CTABanner/CTABanner'
+import { TestimonialContainer } from '@/components/TestimonialBlock/TestimonialBlock'
+import { Link } from '@/components/ui/Link'
+import { Heading } from '@/components/typography/Heading'
+import { Body } from '@/components/typography/Body'
+import { Section } from '@/components/layout/Section'
+import { Container } from '@/components/layout/Container'
+
 export default function AboutPage() {
-  return <p>About — coming soon</p>
+  return (
+    <>
+      <PageHeader eyebrow="About" headline="Brandon Campbell-Kearns" />
+
+      {/* Bio */}
+      <Section>
+        <Container className="max-w-2xl mx-auto">
+          {/* TODO: replace with final copy from DEV-28 */}
+          <Body className="mb-4">
+            I&apos;m a technical instructor and AI implementation consultant based in the Midwest. I got
+            into this work because I kept seeing the same pattern: talented teams stuck on tools they were
+            never properly taught, and small businesses sitting on problems that AI could already solve —
+            if someone would just help them scope it.
+          </Body>
+          <Body>
+            I&apos;ve spent years in the room where engineers learn things — designing curriculum, running
+            workshops, debugging live code with real teams. That experience shapes everything I do, whether
+            I&apos;m teaching a CI/CD workflow or helping a business owner automate their reporting.
+          </Body>
+        </Container>
+      </Section>
+
+      {/* Philosophy */}
+      <Section background="var(--color-secondary)">
+        <Container className="max-w-2xl mx-auto">
+          {/* TODO: replace with final copy from DEV-28 */}
+          <Heading level={2} className="text-white mb-6">How I teach</Heading>
+          <Body className="text-white/70 mb-4">
+            Good instruction starts with knowing what the learner actually needs to be able to do — not
+            what the syllabus says they should know. I design sessions around outcomes, not topics. If
+            your team needs to ship a feature using a new tool, that&apos;s what we practice.
+          </Body>
+          <Body className="text-white/70">
+            I keep sessions tight and hands-on. The best measure of a good workshop is whether people
+            can do the thing the next day without me in the room.
+          </Body>
+        </Container>
+      </Section>
+
+      {/* Proof */}
+      <Section>
+        <Container className="max-w-2xl mx-auto">
+          <Link variant="standalone" href="/work">
+            See our work
+          </Link>
+          {/* TestimonialContainer renders null when items is empty */}
+          <TestimonialContainer items={[]} />
+        </Container>
+      </Section>
+
+      <CTABanner
+        headline="Want to work together?"
+        subtext="Tell us about your project and we'll figure out if we're a good fit."
+        cta={{ label: 'Get in touch', href: '/contact' }}
+      />
+    </>
+  )
 }

--- a/app/(site)/services/page.tsx
+++ b/app/(site)/services/page.tsx
@@ -1,3 +1,68 @@
+import { PageHeader } from '@/components/PageHeader/PageHeader'
+import { CTABanner } from '@/components/CTABanner/CTABanner'
+import { Button } from '@/components/ui/Button'
+import { Divider } from '@/components/ui/Divider'
+import { Heading } from '@/components/typography/Heading'
+import { Body } from '@/components/typography/Body'
+import { Section } from '@/components/layout/Section'
+import { Container } from '@/components/layout/Container'
+
 export default function ServicesPage() {
-  return <p>Services — coming soon</p>
+  return (
+    <>
+      <PageHeader eyebrow="What we do" headline="Services" />
+
+      <div id="training">
+        <Section>
+          <Container className="max-w-3xl mx-auto">
+            {/* TODO: replace with final copy from DEV-28 */}
+            <Heading level={2} className="mb-6">Technical Training for Teams</Heading>
+            <Body className="mb-4">
+              I design and deliver focused technical workshops for engineering teams — built around your
+              specific stack, timeline, and goals. Whether you&apos;re onboarding engineers to a new tool,
+              rolling out a process change, or closing a skills gap, I scope the curriculum to what your
+              team actually needs to do.
+            </Body>
+            <Body className="mb-8">
+              Sessions are instructor-led and hands-on. No slide decks, no generic content off the shelf —
+              just the material your team needs to move forward, taught by someone who&apos;s done the work.
+            </Body>
+            <Button variant="secondary" size="md" as="a" href="/contact">
+              Let&apos;s talk about your team
+            </Button>
+          </Container>
+        </Section>
+      </div>
+
+      <Divider variant="line" />
+
+      <div id="ai-implementation">
+        <Section>
+          <Container className="max-w-3xl mx-auto">
+            {/* TODO: replace with final copy from DEV-28 */}
+            <Heading level={2} className="mb-6">AI Implementation for Small Businesses</Heading>
+            <Body className="mb-4">
+              I work with small business owners to find one real problem AI can solve — then I build it.
+              That might be automating a reporting workflow, drafting a customer communication process, or
+              connecting tools that currently require manual hand-offs. The scope is always clear and the
+              language is always plain.
+            </Body>
+            <Body className="mb-8">
+              No unnecessary complexity, no vague roadmaps. You&apos;ll walk away with something working,
+              and you&apos;ll understand how it works.
+            </Body>
+            <Button variant="secondary" size="md" as="a" href="/contact">
+              Tell us about your project
+            </Button>
+          </Container>
+        </Section>
+      </div>
+
+      <CTABanner
+        headline="Ready to start?"
+        subtext="Tell us what you're working on. We'll figure out if we're a good fit."
+        cta={{ label: 'Get in touch', href: '/contact' }}
+      />
+    </>
+  )
 }


### PR DESCRIPTION
- Replaces one-liner stubs with full component structure using PageHeader, Section, Divider, CTABanner, and typography primitives. Both pages are nav-visible with no workarounds. Anchor links #training and #ai-implementation on Services enable direct linking from home page cards. - Placeholder copy is clearly marked TODO for DEV-28 copy drop-in with no structural changes needed.