### PR TITLE
Scaffolds work index and client detail pages

### DIFF
--- a/app/(site)/work/[client]/page.tsx
+++ b/app/(site)/work/[client]/page.tsx
@@ -1,7 +1,79 @@
-export default function ClientPage({
+import { notFound } from 'next/navigation'
+import { Avatar } from '@/components/ui/Avatar'
+import { Badge } from '@/components/ui/Badge'
+import { Link } from '@/components/ui/Link'
+import { Heading } from '@/components/typography/Heading'
+import { Body } from '@/components/typography/Body'
+import { Label } from '@/components/typography/Label'
+import { Section } from '@/components/layout/Section'
+import { Container } from '@/components/layout/Container'
+import { caseStudies } from '@/data/case-studies'
+import type { CaseStudy } from '@/types/case-study'
+
+const serviceLabel: Record<CaseStudy['service'], string> = {
+  training: 'Training',
+  'ai-implementation': 'AI Implementation',
+}
+
+export async function generateStaticParams() {
+  return caseStudies.map((s) => ({ client: s.slug }))
+}
+
+export default async function ClientPage({
   params,
 }: {
   params: Promise<{ client: string }>
 }) {
-  return <p>Work — client detail coming soon</p>
+  const { client } = await params
+  const study = caseStudies.find((s) => s.slug === client)
+  if (!study) notFound()
+
+  return (
+    <>
+      {/* Page header — dark background matching site nav */}
+      <Section background="var(--color-tertiary)">
+        <Container className="max-w-3xl mx-auto">
+          <Badge label={serviceLabel[study.service]} variant="subtle" className="mb-4" />
+          <Heading level={1} className="text-white mb-2">
+            {study.client}
+          </Heading>
+          <Label className="text-white/60 uppercase tracking-widest">{study.industry}</Label>
+        </Container>
+      </Section>
+
+      {/* Case study body */}
+      <Section>
+        <Container className="max-w-2xl mx-auto">
+          <Avatar variant="initials" name={study.client} size="lg" className="mb-8" />
+
+          <Heading level={3} className="mb-3">
+            The Challenge
+          </Heading>
+          <Body>{study.challenge}</Body>
+
+          <Heading level={3} className="mb-3 mt-8">
+            How We Approached It
+          </Heading>
+          <Body>{study.approach}</Body>
+
+          <Heading level={3} className="mb-3 mt-8">
+            The Outcome
+          </Heading>
+          <Body>{study.outcome}</Body>
+
+          {study.testimonial && (
+            <figure className="border-l-4 border-primary pl-6 mt-8">
+              <blockquote className="font-serif text-h3 italic text-tertiary leading-relaxed">
+                &ldquo;{study.testimonial}&rdquo;
+              </blockquote>
+            </figure>
+          )}
+
+          <Link variant="standalone" href="/work" className="mt-10 block">
+            ← All work
+          </Link>
+        </Container>
+      </Section>
+    </>
+  )
 }

--- a/app/(site)/work/page.tsx
+++ b/app/(site)/work/page.tsx
@@ -1,3 +1,52 @@
+import { FolderOpen } from 'lucide-react'
+import { PageHeader } from '@/components/PageHeader/PageHeader'
+import { EmptyState } from '@/components/ui/EmptyState'
+import { Card, CardHeader, CardBody } from '@/components/ui/Card'
+import { Badge } from '@/components/ui/Badge'
+import { Heading } from '@/components/typography/Heading'
+import { Body } from '@/components/typography/Body'
+import { Label } from '@/components/typography/Label'
+import { Section } from '@/components/layout/Section'
+import { Container } from '@/components/layout/Container'
+import { caseStudies } from '@/data/case-studies'
+import type { CaseStudy } from '@/types/case-study'
+
+const serviceLabel: Record<CaseStudy['service'], string> = {
+  training: 'Training',
+  'ai-implementation': 'AI Implementation',
+}
+
 export default function WorkPage() {
-  return <p>Work — coming soon</p>
+  return (
+    <>
+      <PageHeader eyebrow="Portfolio" headline="Our Work" />
+
+      <Section>
+        <Container>
+          {caseStudies.length === 0 ? (
+            <EmptyState
+              icon={FolderOpen}
+              heading="Case studies coming soon."
+              description="We're documenting our engagements. Check back soon."
+            />
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+              {caseStudies.map((study) => (
+                <Card key={study.slug} variant="interactive" href={`/work/${study.slug}`}>
+                  <CardHeader>
+                    <Badge label={serviceLabel[study.service]} variant="subtle" className="mb-3" />
+                    <Heading level={3}>{study.client}</Heading>
+                    <Label className="text-neutral mt-1 block">{study.industry}</Label>
+                  </CardHeader>
+                  <CardBody>
+                    <Body>{study.outcome}</Body>
+                  </CardBody>
+                </Card>
+              ))}
+            </div>
+          )}
+        </Container>
+      </Section>
+    </>
+  )
 }

--- a/data/case-studies.ts
+++ b/data/case-studies.ts
@@ -1,0 +1,16 @@
+import type { CaseStudy } from '@/types/case-study'
+
+export type CaseStudyEntry = CaseStudy & { slug: string }
+
+export const caseStudies: CaseStudyEntry[] = [
+  // TODO: add real case studies from DEV-28
+  // {
+  //   slug: 'midwest-tech-co',
+  //   client: 'Midwest Tech Co.',
+  //   industry: 'Technology',
+  //   service: 'training',
+  //   challenge: '...',
+  //   approach: '...',
+  //   outcome: 'Trained 12 engineers on a new CI/CD pipeline across 3 focused sessions.',
+  // },
+]


### PR DESCRIPTION
- Adds the work section with responsive card grid (1→2→3 cols) and a case study detail template. Both pages are driven by data/case-studies.ts — a static array that starts empty, showing an EmptyState until entries are added. The detail page uses generateStaticParams for static pre-rendering and notFound() for unknown slugs. Case study content plugs in from DEV-28 with no structural changes needed.

- CMS migration (replacing the static file with a CMS fetch) is tracked as TD-003 — page structure stays the same when that happens.