### PR TITLE
Restyles podcast page with server-side RSS fetch and error boundary

### DIFF
--- a/app/(site)/podcast/page.tsx
+++ b/app/(site)/podcast/page.tsx
@@ -1,3 +1,65 @@
-export default function PodcastPage() {
-  return <p>Podcast — coming soon</p>
+import { getPodcastEpisodes } from '@/lib/podcast'
+import { PageHeader } from '@/components/PageHeader/PageHeader'
+import { StatusMessage } from '@/components/ui/StatusMessage'
+import { Card, CardHeader, CardBody } from '@/components/ui/Card'
+import { Heading } from '@/components/typography/Heading'
+import { Body } from '@/components/typography/Body'
+import { Caption } from '@/components/typography/Caption'
+import { Link } from '@/components/ui/Link'
+import { Section } from '@/components/layout/Section'
+import { Container } from '@/components/layout/Container'
+import type { Episode } from '@/lib/podcast'
+
+export default async function PodcastPage() {
+  let episodes: Episode[] = []
+  let fetchError = false
+
+  try {
+    episodes = await getPodcastEpisodes()
+  } catch {
+    fetchError = true
+  }
+
+  return (
+    <>
+      <PageHeader eyebrow="Listen" headline="Podcast" />
+      <Section>
+        <Container className="max-w-2xl mx-auto">
+          {fetchError ? (
+            <StatusMessage
+              variant="error"
+              message="Unable to load podcast episodes right now. Please try again later."
+            />
+          ) : episodes.length === 0 ? (
+            <StatusMessage variant="info" message="No episodes found." />
+          ) : (
+            <div className="flex flex-col gap-6">
+              {episodes.map(ep => (
+                <Card key={ep.title} variant="default">
+                  <CardHeader>
+                    {ep.pubDate && (
+                      <Caption className="mb-2 block">
+                        {new Date(ep.pubDate).toLocaleDateString('en-US', {
+                          year: 'numeric',
+                          month: 'long',
+                          day: 'numeric',
+                        })}
+                      </Caption>
+                    )}
+                    <Heading level={3}>{ep.title}</Heading>
+                  </CardHeader>
+                  <CardBody>
+                    <Body className="line-clamp-3">{ep.description}</Body>
+                    <Link variant="standalone" href={ep.link} external className="mt-4 block">
+                      Listen to episode
+                    </Link>
+                  </CardBody>
+                </Card>
+              ))}
+            </div>
+          )}
+        </Container>
+      </Section>
+    </>
+  )
 }

--- a/lib/podcast.ts
+++ b/lib/podcast.ts
@@ -1,0 +1,35 @@
+export type Episode = {
+  title: string
+  description: string
+  link: string
+  pubDate: string
+}
+
+/** Extract first match of a tag, handling CDATA and plain text */
+function extractTag(xml: string, tag: string): string {
+  const cdata = xml.match(new RegExp(`<${tag}[^>]*><!\\[CDATA\\[([\\s\\S]*?)\\]\\]><\\/${tag}>`))
+  if (cdata) return cdata[1].trim()
+  const plain = xml.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`))
+  return plain ? plain[1].trim() : ''
+}
+
+/** Strip HTML tags from a string */
+function stripHtml(html: string): string {
+  return html.replace(/<[^>]+>/g, '').trim()
+}
+
+export async function getPodcastEpisodes(): Promise<Episode[]> {
+  const res = await fetch('https://anchor.fm/s/cde5081c/podcast/rss', {
+    next: { revalidate: 3600 },
+  })
+  if (!res.ok) throw new Error(`RSS fetch failed: ${res.status}`)
+  const xml = await res.text()
+
+  const items = xml.match(/<item>[\s\S]*?<\/item>/g) ?? []
+  return items.map(item => ({
+    title: extractTag(item, 'title'),
+    description: stripHtml(extractTag(item, 'description')),
+    link: extractTag(item, 'link'),
+    pubDate: extractTag(item, 'pubDate'),
+  }))
+}


### PR DESCRIPTION
- Replaces the one-liner stub with PageHeader + a card list of episodes. The legacy client-side DOMParser approach couldn't work in App Router server components, so RSS parsing moves to a new lib/podcast.ts utility using native fetch with 1-hour ISR revalidation and regex-based XML extraction (no new dependencies).

- The try/catch around getPodcastEpisodes() acts as the error boundary — PageHeader always renders; a failed fetch or empty feed shows StatusMessage
rather than crashing the page.